### PR TITLE
Changed modifiers to more closely match Chrome's behavior

### DIFF
--- a/build/hook.js
+++ b/build/hook.js
@@ -66,13 +66,12 @@
 
     DomUtils.prototype.simulateClick = function(element, modifiers) {
       var event, eventSequence, mouseEvent, _i, _len, _results;
-      modifiers || (modifiers = {});
       eventSequence = ["mouseover", "mousedown", "mouseup", "click"];
       _results = [];
       for (_i = 0, _len = eventSequence.length; _i < _len; _i++) {
         event = eventSequence[_i];
         mouseEvent = document.createEvent("MouseEvents");
-        mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, false, false, modifiers.metaKey, 0, null);
+        mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, false, modifiers.shiftKey, modifiers.metaKey, 0, null);
         _results.push(element.dispatchEvent(mouseEvent));
       }
       return _results;
@@ -124,21 +123,19 @@
       return this.update_link_focus();
     };
 
-    Application.prototype.follow_link = function(link, new_window) {
+    Application.prototype.follow_focused_link = function(ctrlOrMetaPressed, shiftPressed) {
       var modifiers;
-      if (new_window) {
+      modifiers = {};
+      if (ctrlOrMetaPressed) {
         modifiers = {
           metaKey: this.dom_utils.platform === "Mac",
           ctrlKey: this.dom_utils.platform !== "Mac"
         };
-      } else {
-        $(link).addClass("deadmouse-clicked");
       }
-      return this.dom_utils.simulateClick(link, modifiers);
-    };
-
-    Application.prototype.follow_focused_link = function(new_window) {
-      return this.follow_link(this.matched_links[this.focused_link_index], new_window);
+      if (shiftPressed) {
+        modifiers.shiftKey = true;
+      }
+      return this.dom_utils.simulateClick(this.matched_links[this.focused_link_index], modifiers);
     };
 
     Application.prototype.clear = function() {
@@ -191,11 +188,7 @@
         return false;
       } else if (this.activated && event.keyCode === 13) {
         this.clear();
-        if (event.shiftKey) {
-          this.follow_focused_link(true);
-        } else {
-          this.follow_focused_link(false);
-        }
+        this.follow_focused_link(event.ctrlKey || event.metaKey, event.shiftKey);
         this.reset();
         return false;
       }

--- a/build/hook.js
+++ b/build/hook.js
@@ -123,18 +123,13 @@
       return this.update_link_focus();
     };
 
-    Application.prototype.follow_focused_link = function(ctrlOrMetaPressed, shiftPressed) {
+    Application.prototype.follow_focused_link = function(ctrlPressed, metaPressed, shiftPressed) {
       var modifiers;
-      modifiers = {};
-      if (ctrlOrMetaPressed) {
-        modifiers = {
-          metaKey: this.dom_utils.platform === "Mac",
-          ctrlKey: this.dom_utils.platform !== "Mac"
-        };
-      }
-      if (shiftPressed) {
-        modifiers.shiftKey = true;
-      }
+      modifiers = {
+        ctrlKey: ctrlPressed,
+        metaKey: metaPressed,
+        shiftKey: shiftPressed
+      };
       return this.dom_utils.simulateClick(this.matched_links[this.focused_link_index], modifiers);
     };
 
@@ -188,7 +183,7 @@
         return false;
       } else if (this.activated && event.keyCode === 13) {
         this.clear();
-        this.follow_focused_link(event.ctrlKey || event.metaKey, event.shiftKey);
+        this.follow_focused_link(event.ctrlKey, event.metaKey, event.shiftKey);
         this.reset();
         return false;
       }

--- a/src/hook.coffee
+++ b/src/hook.coffee
@@ -56,14 +56,11 @@ class Application
       this.focused_link_index = this.matched_links.length - 1
     this.update_link_focus()
     
-  follow_focused_link: (ctrlOrMetaPressed, shiftPressed) ->
-    modifiers = {}
-    if ctrlOrMetaPressed
-      modifiers =
-        metaKey: this.dom_utils.platform == "Mac"
-        ctrlKey: this.dom_utils.platform != "Mac"
-    if shiftPressed
-      modifiers.shiftKey = true
+  follow_focused_link: (ctrlPressed, metaPressed, shiftPressed) ->
+    modifiers =
+        ctrlKey: ctrlPressed
+        metaKey: metaPressed
+        shiftKey: shiftPressed
     this.dom_utils.simulateClick(this.matched_links[this.focused_link_index], modifiers)
     
   clear: ->
@@ -107,7 +104,7 @@ class Application
     else if this.activated and event.keyCode == 13 # Enter pressed
       this.clear()
 
-      this.follow_focused_link(event.ctrlKey or event.metaKey, event.shiftKey)
+      this.follow_focused_link(event.ctrlKey, event.metaKey, event.shiftKey)
 
       this.reset()
       return false

--- a/src/hook.coffee
+++ b/src/hook.coffee
@@ -17,12 +17,10 @@ class DomUtils
       @platform = "Windows"
 
   simulateClick: (element, modifiers) ->
-    modifiers ||= {}
-
     eventSequence = ["mouseover", "mousedown", "mouseup", "click"]
     for event in eventSequence
       mouseEvent = document.createEvent("MouseEvents")
-      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, false, false, modifiers.metaKey, 0, null)
+      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, false, modifiers.shiftKey, modifiers.metaKey, 0, null)
       element.dispatchEvent(mouseEvent)
 
 class Application
@@ -58,17 +56,15 @@ class Application
       this.focused_link_index = this.matched_links.length - 1
     this.update_link_focus()
     
-  follow_link: (link, new_window) ->
-    if new_window
+  follow_focused_link: (ctrlOrMetaPressed, shiftPressed) ->
+    modifiers = {}
+    if ctrlOrMetaPressed
       modifiers =
         metaKey: this.dom_utils.platform == "Mac"
         ctrlKey: this.dom_utils.platform != "Mac"
-    else
-      $(link).addClass("deadmouse-clicked")
-    this.dom_utils.simulateClick(link, modifiers)
-
-  follow_focused_link: (new_window) ->
-    this.follow_link(this.matched_links[this.focused_link_index], new_window)
+    if shiftPressed
+      modifiers.shiftKey = true
+    this.dom_utils.simulateClick(this.matched_links[this.focused_link_index], modifiers)
     
   clear: ->
     $(link).removeClass("deadmouse-focused") for link in $("a")
@@ -111,10 +107,7 @@ class Application
     else if this.activated and event.keyCode == 13 # Enter pressed
       this.clear()
 
-      if event.shiftKey
-        this.follow_focused_link(true)
-      else
-        this.follow_focused_link(false)
+      this.follow_focused_link(event.ctrlKey or event.metaKey, event.shiftKey)
 
       this.reset()
       return false


### PR DESCRIPTION
`Cmd/Ctrl+Enter` now opens the link in a new tab, `Shift+Enter` opens it in a new window, and `Cmd/Ctrl+Shift+Enter` opens it in a new tab and switches to it.
