### PR TITLE
Fixed order of operations when pressing escape

### DIFF
--- a/build/hook.js
+++ b/build/hook.js
@@ -169,7 +169,7 @@
     };
 
     Application.prototype.keydown = function(event) {
-      if (event.keyCode === 27 || event.keyCode === 8 && this.activated) {
+      if ((event.keyCode === 27 || event.keyCode === 8) && this.activated) {
         this.clear();
         this.reset();
         return false;

--- a/src/hook.coffee
+++ b/src/hook.coffee
@@ -87,7 +87,7 @@ class Application
       return true
   
   keydown: (event) ->
-    if event.keyCode == 27 or event.keyCode == 8 and this.activated # Esc or Backspace pressed
+    if (event.keyCode == 27 or event.keyCode == 8) and this.activated # Esc or Backspace pressed
       this.clear()
       this.reset()
       


### PR DESCRIPTION
deadmouse wasn't allowing me to press escape to stop loading a page, even when deadmouse wasn't activated. So I fixed it. Turns out it was a simple matter of leaving out a pair of parentheses :) .
